### PR TITLE
The "No fractional part" option value had wrong effect

### DIFF
--- a/src/classes/XLite/Logic/Math.php
+++ b/src/classes/XLite/Logic/Math.php
@@ -88,7 +88,7 @@ class Math extends \XLite\Logic\ALogic
 
         return number_format(
             $this->roundByCurrency($value, $currency),
-            $currency->getE(),
+            $config->General->decimal_delim ? $currency->getE() : 0,
             $config->General->decimal_delim,
             $config->General->thousand_delim
         );


### PR DESCRIPTION
The General settings -> "Currency decimal separator:" option did not work properly with "No fractional part" value.
